### PR TITLE
Merge GraphX to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Here's a simple script that extracts and counts the top-level domains (i.e., num
 import org.warcbase.spark.matchbox._
 import org.warcbase.spark.rdd.RecordRDD._
 
-val r = RecordLoader.loadArc("src/test/resources/arc/example.arc.gz", sc)
+val r = RecordLoader.loadArchives("src/test/resources/arc/example.arc.gz", sc)
   .keepValidPages()
   .map(r => ExtractTopLevelDomain(r.getUrl))
   .countItems()

--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jettyVersion>8.1.12.v20130726</jettyVersion>
-    <hadoop.version>2.6.0-cdh5.4.1</hadoop.version>
-    <hbase.version>1.0.0-cdh5.4.1</hbase.version>
-    <zookeeper.version>3.4.5-cdh5.4.1</zookeeper.version>
-    <spark.version>1.3.0-cdh5.4.1</spark.version>
+    <hadoop.version>2.6.0-cdh5.6.0</hadoop.version>
+    <hbase.version>1.0.0-cdh5.6.0</hbase.version>
+    <zookeeper.version>3.4.5-cdh5.6.0</zookeeper.version>
+    <spark.version>1.5.0-cdh5.6.0</spark.version>
     <scala.version>2.10.4</scala.version>
   </properties>
 
@@ -281,7 +281,7 @@ http://mail-archives.apache.org/mod_mbox/lucene-java-user/201308.mbox/%3CWC20130
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version> <!-- downgrade for Hadoop WARC indexer -->
+      <version>19.0</version> <!-- OK? was 14.0.1 ("downgrade for Hadoop WARC indexer") -->
     </dependency>
     <dependency>
       <groupId>tl.lin</groupId>
@@ -448,6 +448,11 @@ http://mail-archives.apache.org/mod_mbox/lucene-java-user/201308.mbox/%3CWC20130
       </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-graphx_2.10</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.chuusai</groupId>
@@ -457,13 +462,13 @@ http://mail-archives.apache.org/mod_mbox/lucene-java-user/201308.mbox/%3CWC20130
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jettyVersion>8.1.12.v20130726</jettyVersion>
-    <hadoop.version>2.6.0-cdh5.6.0</hadoop.version>
-    <hbase.version>1.0.0-cdh5.6.0</hbase.version>
-    <zookeeper.version>3.4.5-cdh5.6.0</zookeeper.version>
-    <spark.version>1.5.0-cdh5.6.0</spark.version>
+    <hadoop.version>2.6.0-cdh5.4.1</hadoop.version>
+    <hbase.version>1.0.0-cdh5.4.1</hbase.version>
+    <zookeeper.version>3.4.5-cdh5.4.1</zookeeper.version>
+    <spark.version>1.3.0-cdh5.4.1</spark.version>    
     <scala.version>2.10.4</scala.version>
   </properties>
 
@@ -281,7 +281,7 @@ http://mail-archives.apache.org/mod_mbox/lucene-java-user/201308.mbox/%3CWC20130
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version> <!-- OK? was 14.0.1 ("downgrade for Hadoop WARC indexer") -->
+      <version>19.0</version>
     </dependency>
     <dependency>
       <groupId>tl.lin</groupId>

--- a/src/main/scala/org/warcbase/spark/matchbox/ExtractGraph.scala
+++ b/src/main/scala/org/warcbase/spark/matchbox/ExtractGraph.scala
@@ -1,0 +1,69 @@
+/*
+ * Warcbase: an open-source platform for managing web archives
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.warcbase.spark.matchbox
+
+import org.apache.spark.graphx._
+import org.apache.spark.rdd.RDD
+import org.warcbase.spark.archive.io.ArchiveRecord
+import org.warcbase.spark.rdd.RecordRDD._
+import org.warcbase.spark.utils.JsonUtil
+
+/**
+  *
+  * e.g. when done:
+  * $ cat nodes.partjson/part-* > nodes.json && cat links.partjson/part-* > links.json
+  * $ jq -c -n --slurpfile nodes nodes.json --slurpfile links links.json '{nodes: $nodes, links: $links}' > graph.json
+  *
+  */
+
+object ExtractGraph {
+  def pageHash(url: String): VertexId = {
+    url.hashCode.toLong
+  }
+
+  case class RichVertex(domain: String, pageRank: Double, inDegree: Int, outDegree: Int)
+  case class RichEdge(date: String, src: String, dst: String, count: Long)
+
+  def apply(records: RDD[ArchiveRecord], nodesPath: String, linksPath: String) {
+    val vertices: RDD[(VertexId, RichVertex)] = records.keepValidPages()
+      .flatMap(r => ExtractLinks(r.getUrl, r.getContentString))
+      .flatMap(r => List(ExtractTopLevelDomain(r._1).replaceAll("^\\s*www\\.", ""), ExtractTopLevelDomain(r._2).replaceAll("^\\s*www\\.", "")))
+      .distinct
+      .map(r => (pageHash(r), RichVertex(r, 0.0, 0, 0)))
+
+    val edges: RDD[Edge[RichEdge]] = records.keepValidPages()
+      .map(r => (r.getCrawldate, ExtractLinks(r.getUrl, r.getContentString)))
+      .flatMap(r => r._2.map(f => (r._1, ExtractTopLevelDomain(f._1).replaceAll("^\\s*www\\.", ""), ExtractTopLevelDomain(f._2).replaceAll("^\\s*www\\.", ""))))
+      .filter(r => r._2 != null && r._3 != null)
+      .countItems()
+      .map(r => Edge(pageHash(r._1._2), pageHash(r._1._3), RichEdge(r._1._1, r._1._2, r._1._3, r._2)))
+
+    val graph = Graph(vertices, edges)
+
+    val richGraph = graph.outerJoinVertices(graph.inDegrees) {
+      case (vid, rv, inDegOpt) => RichVertex(rv.domain, rv.pageRank, inDegOpt.getOrElse(0), rv.outDegree)
+    }.outerJoinVertices(graph.outDegrees) {
+      case (vid, rv, outDegOpt) => RichVertex(rv.domain, rv.pageRank, rv.inDegree, outDegOpt.getOrElse(0))
+    }.outerJoinVertices(graph.pageRank(0.00001).vertices) {
+      case (vid, rv, pageRankOpt) => RichVertex(rv.domain, pageRankOpt.getOrElse(0.0), rv.inDegree, rv.outDegree)
+    }
+
+    richGraph.vertices.map(r => JsonUtil.toJson(r._2)).saveAsTextFile(nodesPath)
+    richGraph.edges.map(r => JsonUtil.toJson(r.attr)).saveAsTextFile(linksPath)
+  }
+}
+

--- a/src/main/scala/org/warcbase/spark/matchbox/NERCombinedJson.scala
+++ b/src/main/scala/org/warcbase/spark/matchbox/NERCombinedJson.scala
@@ -6,12 +6,8 @@ import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
-import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
-import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-
+import org.warcbase.spark.utils.JsonUtil
 import scala.collection.mutable.MutableList
 import scala.util.Random
 
@@ -83,17 +79,17 @@ class NERCombinedJson extends Serializable {
           })
           .map(r => {
             val classifiedJson = NER3Classifier.classify(r._3)
-            val jUtl = new JsonUtil
-            val classifiedMap = jUtl.fromJson[Map[String,List[String]]](classifiedJson)
+            //val jUtl = new JsonUtil
+            //val classifiedMap = JsonUtil.fromJson[Map[String,List[String]]](classifiedJson)
+            val classifiedMap = JsonUtil.fromJson(classifiedJson)
             val classifiedMapCountTuples: Map[String, List[(String, Int)]] = classifiedMap.map {
-              case (nerType, entityList) => (nerType, entityList.groupBy(identity).mapValues(_.size).toList)
+              case (nerType, entityList: List[String]) => (nerType, entityList.groupBy(identity).mapValues(_.size).toList)
             }
             ((r._1, r._2), classifiedMapCountTuples)
           })
       })
       .reduceByKey( (a, b) => (a ++ b).keySet.map(r => (r, combineKeyCountLists(a(r), b(r)))).toMap)
       .mapPartitions(iter => {
-        val jUtl = new JsonUtil
         iter.map(r => {
           val nerRec = new NerRecord(r._1._1, r._1._2)
           r._2.foreach(entityMap => {  
@@ -104,7 +100,7 @@ class NERCombinedJson extends Serializable {
             })
             nerRec.ner += ec
           })
-          jUtl.toJson(nerRec)
+          JsonUtil.toJson(nerRec)
         })
       })
       .saveAsTextFile(outputFile)
@@ -130,20 +126,4 @@ class NERCombinedJson extends Serializable {
   }
 }
 
-class JsonUtil extends Serializable {
-  val mapper = new ObjectMapper() with ScalaObjectMapper
-  mapper.registerModule(DefaultScalaModule)
-  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
-  def toJson(value: Map[Symbol, Any]): String = {
-    toJson(value map { case (k,v) => k.name -> v})
-  }
-
-  def toJson(value: Any): String = {
-    mapper.writeValueAsString(value)
-  }
-
-  def fromJson[T](json: String)(implicit m : Manifest[T]): T = {
-    mapper.readValue[T](json)
-  }
-}

--- a/src/main/scala/org/warcbase/spark/utils/JsonUtil.scala
+++ b/src/main/scala/org/warcbase/spark/utils/JsonUtil.scala
@@ -1,0 +1,22 @@
+package org.warcbase.spark.utils
+
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+object JsonUtil extends Serializable {
+  val mapper = new ObjectMapper()
+  mapper.registerModule(DefaultScalaModule)
+  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+  def toJson(value: Map[Symbol, Any]): String = {
+    toJson(value map { case (k,v) => k.name -> v})
+  }
+
+  def toJson(value: Any): String = {
+    mapper.writeValueAsString(value)
+  }
+
+  def fromJson(json: String): Map[String, Any] = {
+    mapper.readValue(json, classOf[Map[String, Any]])
+  }
+}


### PR DESCRIPTION
I think the ExtractGraph object is functionally ready to be merged into master, but I'm interested in feedback about how it's implemented and invoked.

At present one would call it thusly:
```
import org.warcbase.spark.rdd.RecordRDD._
import org.warcbase.spark.matchbox.RecordLoader
import org.warcbase.spark.matchbox.ExtractGraph

val recs = RecordLoader.loadArchives("/collections/webarchives/CanadianPoliticalParties/warc/", sc)

val graph = ExtractGraph(recs)
// Gives you a resilient distributed Graph, with edges and vertices contain the following:
//      case class VertexData(domain: String, pageRank: Double, inDegree: Int, outDegree: Int)
//      case class EdgeData(date: String, src: String, dst: String)

// Here you have the opportunity to manipulate graph if you like (e.g., subgraph).
// See https://spark.apache.org/docs/latest/graphx-programming-guide.html#summary-list-of-operators

// To write the graph as JSON, do this:
graph.writeAsJson("nodes-dir", "links-dir")
```

A few thoughts:
* Might it be desirable to do _less_ with the `apply` method (invoked when you call ExtractGraph(recs))? Currently it generates the Graph from our archive RDD, and runs `inDegrees`, `outDegrees`, and `PageRank`. Should we give the user more fine-grained control and just generate the graph and then have a separate method `getStats` (or getInDegrees, getOutDegrees, getPageRank) that runs the latter operations? Should we parameterize the PageRank call, allowing for choice between dynamic PageRank (`pageRank(tolerance: Double)`) and static (`staticPageRank(numIterations: Int)`)? Or does this complicate usage too much?
* Nomenclature: we have several other Extract* objects, which is why I used this name. But does "extract" seem like the right verb for what we're doing here? Would something like GraphBuilder or simply Graph be a better name for this?
* I could make the `apply` method take the ArchiveRecord RDD implicitly, so it could be called through our fluent interface. E.g., in one shot, `RecordLoader.loadArchives("/path/to/warcs/", sc).keepLanguages(Set("fr")).(ExtractGraph.writeAsJson("nodes", "links")`. Is it better, however, to limit the number of data types we pass through the method chain?

All of these things involve only minor changes and aren't maybe very consequential, but obviously it's preferable to settle these basic details before code examples start appearing in our published papers.