### PR TITLE
renaming ExtractTopLevelDomain to ExtractDomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import org.warcbase.spark.rdd.RecordRDD._
 
 val r = RecordLoader.loadArchives("src/test/resources/arc/example.arc.gz", sc)
   .keepValidPages()
-  .map(r => ExtractTopLevelDomain(r.getUrl))
+  .map(r => ExtractDomain(r.getUrl))
   .countItems()
   .take(10)
 ```

--- a/src/main/scala/org/warcbase/spark/archive/io/ArcRecord.scala
+++ b/src/main/scala/org/warcbase/spark/archive/io/ArcRecord.scala
@@ -4,7 +4,7 @@ import org.apache.spark.SerializableWritable
 import org.warcbase.data.ArcRecordUtils
 import org.warcbase.io.ArcRecordWritable
 import org.warcbase.spark.matchbox.ExtractDate.DateComponent
-import org.warcbase.spark.matchbox.{ExtractDate, ExtractTopLevelDomain}
+import org.warcbase.spark.matchbox.{ExtractDate, ExtractDomain}
 
 class ArcRecord(r: SerializableWritable[ArcRecordWritable]) extends ArchiveRecord {
   val getCrawldate: String = ExtractDate(r.t.getRecord.getMetaData.getDate, DateComponent.YYYYMMDD)
@@ -13,7 +13,7 @@ class ArcRecord(r: SerializableWritable[ArcRecordWritable]) extends ArchiveRecor
 
   val getUrl: String = r.t.getRecord.getMetaData.getUrl
 
-  val getDomain: String = ExtractTopLevelDomain(r.t.getRecord.getMetaData.getUrl)
+  val getDomain: String = ExtractDomain(r.t.getRecord.getMetaData.getUrl)
 
   val getContentBytes: Array[Byte] = ArcRecordUtils.getBodyContent(r.t.getRecord)
 

--- a/src/main/scala/org/warcbase/spark/archive/io/GenericArchiveRecord.scala
+++ b/src/main/scala/org/warcbase/spark/archive/io/GenericArchiveRecord.scala
@@ -11,7 +11,7 @@ import org.warcbase.data.{ArcRecordUtils, WarcRecordUtils}
 import org.warcbase.io.GenericArchiveRecordWritable
 import org.warcbase.io.GenericArchiveRecordWritable.ArchiveFormat
 import org.warcbase.spark.matchbox.ExtractDate.DateComponent
-import org.warcbase.spark.matchbox.{ExtractDate, ExtractTopLevelDomain}
+import org.warcbase.spark.matchbox.{ExtractDate, ExtractDomain}
 
 class GenericArchiveRecord(r: SerializableWritable[GenericArchiveRecordWritable]) extends ArchiveRecord {
   var arcRecord: ARCRecord = null
@@ -59,5 +59,5 @@ class GenericArchiveRecord(r: SerializableWritable[GenericArchiveRecordWritable]
     }
   }
 
-  val getDomain: String = ExtractTopLevelDomain(getUrl)
+  val getDomain: String = ExtractDomain(getUrl)
 }

--- a/src/main/scala/org/warcbase/spark/archive/io/WarcRecord.scala
+++ b/src/main/scala/org/warcbase/spark/archive/io/WarcRecord.scala
@@ -7,7 +7,7 @@ import org.archive.util.ArchiveUtils
 import org.warcbase.data.WarcRecordUtils
 import org.warcbase.io.WarcRecordWritable
 import org.warcbase.spark.matchbox.ExtractDate.DateComponent
-import org.warcbase.spark.matchbox.{ExtractDate, ExtractTopLevelDomain}
+import org.warcbase.spark.matchbox.{ExtractDate, ExtractDomain}
 
 class WarcRecord(r: SerializableWritable[WarcRecordWritable]) extends ArchiveRecord {
   val ISO8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX")
@@ -22,5 +22,5 @@ class WarcRecord(r: SerializableWritable[WarcRecordWritable]) extends ArchiveRec
 
   val getUrl = r.t.getRecord.getHeader.getUrl
 
-  val getDomain = ExtractTopLevelDomain(getUrl)
+  val getDomain = ExtractDomain(getUrl)
 }

--- a/src/main/scala/org/warcbase/spark/matchbox/ExtractDomain.scala
+++ b/src/main/scala/org/warcbase/spark/matchbox/ExtractDomain.scala
@@ -18,7 +18,7 @@ package org.warcbase.spark.matchbox
 
 import java.net.URL
 
-object ExtractTopLevelDomain {
+object ExtractDomain {
   def apply(url: String, source: String = ""): String = {
     if (url == null) return null
     var host: String = null

--- a/src/main/scala/org/warcbase/spark/rdd/RecordRDD.scala
+++ b/src/main/scala/org/warcbase/spark/rdd/RecordRDD.scala
@@ -18,7 +18,7 @@ package org.warcbase.spark.rdd
 
 import org.apache.spark.rdd.RDD
 import org.warcbase.spark.archive.io.ArchiveRecord
-import org.warcbase.spark.matchbox.{DetectLanguage, ExtractDate, ExtractTopLevelDomain, RemoveHTML}
+import org.warcbase.spark.matchbox.{DetectLanguage, ExtractDate, ExtractDomain, RemoveHTML}
 import org.warcbase.spark.matchbox.ExtractDate.DateComponent
 import org.warcbase.spark.matchbox.ExtractDate.DateComponent.DateComponent
 
@@ -79,7 +79,7 @@ object RecordRDD extends java.io.Serializable {
     }
 
     def keepDomains(urls: Set[String]) = {
-      rdd.filter(r => urls.contains(ExtractTopLevelDomain(r.getUrl).replace("^\\s*www\\.", "")))
+      rdd.filter(r => urls.contains(ExtractDomain(r.getUrl).replace("^\\s*www\\.", "")))
     }
 
     def keepLanguages(lang: Set[String]) = {

--- a/src/main/scala/org/warcbase/spark/scripts/CrawlStatistics.scala
+++ b/src/main/scala/org/warcbase/spark/scripts/CrawlStatistics.scala
@@ -2,7 +2,7 @@ package org.warcbase.spark.scripts
 
 import com.google.common.io.Resources
 import org.apache.spark.{SparkConf, SparkContext}
-import org.warcbase.spark.matchbox.{ExtractLinks, ExtractTopLevelDomain, RecordLoader}
+import org.warcbase.spark.matchbox.{ExtractLinks, ExtractDomain, RecordLoader}
 import org.warcbase.spark.matchbox._
 import org.warcbase.spark.rdd.RecordRDD._
 
@@ -50,7 +50,7 @@ object CrawlStatistics {
     val linkStructure = RecordLoader.loadArc(arcPath, sc)
       .keepValidPages()
       .map(r => (r.getCrawldate.substring(0, 6), ExtractLinks(r.getUrl, r.getContentString)))
-      .flatMap(r => r._2.map(f => (r._1, ExtractTopLevelDomain(f._1).replaceAll("^\\s*www\\.", ""), ExtractTopLevelDomain(f._2).replaceAll("^\\s*www\\.", ""))))
+      .flatMap(r => r._2.map(f => (r._1, ExtractDomain(f._1).replaceAll("^\\s*www\\.", ""), ExtractDomain(f._2).replaceAll("^\\s*www\\.", ""))))
       .filter(r => r._2 != null && r._3 != null)
       .countItems()
       .collect()
@@ -61,7 +61,7 @@ object CrawlStatistics {
     val linkStructure = RecordLoader.loadWarc(warcPath, sc)
       .keepValidPages()
       .map(r => (ExtractDate(r.getCrawldate, ExtractDate.DateComponent.YYYYMM), ExtractLinks(r.getUrl, r.getContentString)))
-      .flatMap(r => r._2.map(f => (r._1, ExtractTopLevelDomain(f._1).replaceAll("^\\s*www\\.", ""), ExtractTopLevelDomain(f._2).replaceAll("^\\s*www\\.", ""))))
+      .flatMap(r => r._2.map(f => (r._1, ExtractDomain(f._1).replaceAll("^\\s*www\\.", ""), ExtractDomain(f._2).replaceAll("^\\s*www\\.", ""))))
       .filter(r => r._2 != null && r._3 != null)
       .countItems()
       .map(r => TupleFormatter.tabDelimit(r))

--- a/src/test/scala/org/warcbase/spark/matchbox/ExtractDomainTest.scala
+++ b/src/test/scala/org/warcbase/spark/matchbox/ExtractDomainTest.scala
@@ -21,7 +21,7 @@ import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ExtractTopLevelDomainTest extends FunSuite {
+class ExtractDomainTest extends FunSuite {
 
   private val data1: Seq[(String, String)] = Seq.newBuilder.+=(
     ("http://www.umiacs.umd.edu/~jimmylin/", "www.umiacs.umd.edu"),
@@ -35,12 +35,12 @@ class ExtractTopLevelDomainTest extends FunSuite {
 
   test("simple") {
     data1.foreach {
-      case (link, domain) => assert(ExtractTopLevelDomain(link) == domain)
+      case (link, domain) => assert(ExtractDomain(link) == domain)
     }
   }
   test("withBase") {
     data2.foreach {
-      case (link, base, domain) => assert(ExtractTopLevelDomain(link, base) == domain)
+      case (link, base, domain) => assert(ExtractDomain(link, base) == domain)
     }
   }
 }

--- a/src/test/scala/org/warcbase/spark/rdd/CountableRDDTest.scala
+++ b/src/test/scala/org/warcbase/spark/rdd/CountableRDDTest.scala
@@ -41,7 +41,7 @@ class CountableRDDTest extends FunSuite with BeforeAndAfter {
   test("count records") {
     val base = RecordLoader.loadArc(arcPath, sc)
       .keepValidPages()
-      .map(r => ExtractTopLevelDomain(r.getUrl))
+      .map(r => ExtractDomain(r.getUrl))
     val r = base
       .map(r => (r, 1))
       .reduceByKey(_ + _)


### PR DESCRIPTION
Responding to Issue #208. This is just a straight replacement of `ExtractTopLevelDomain` with `ExtractDomain`. I've tested it on analytics scripts, text extraction scripts, and network analysis scripts and all seems to work.

Once merged, I will update warcbase-docs accordingly.