### PR TITLE
Adding keepContent to warcbase

### DIFF
--- a/src/main/scala/org/warcbase/spark/rdd/RecordRDD.scala
+++ b/src/main/scala/org/warcbase/spark/rdd/RecordRDD.scala
@@ -86,6 +86,15 @@ object RecordRDD extends java.io.Serializable {
       rdd.filter(r => lang.contains(DetectLanguage(RemoveHTML(r.getContentString))))
     }
 
+    def keepContent(contentREs: Set[Regex]) = {
+      rdd.filter(r =>
+        contentREs.map(re =>
+          (re findFirstIn r.getContentString) match {
+            case Some(v) => true
+            case None => false
+          }).exists(identity))
+    }
+
     def discardMimeTypes(mimeTypes: Set[String]) = {
       rdd.filter(r => !mimeTypes.contains(r.getMimeType))
     }
@@ -109,6 +118,15 @@ object RecordRDD extends java.io.Serializable {
 
     def discardDomains(urls: Set[String]) = {
       rdd.filter(r => !urls.contains(r.getDomain))
+    }
+
+    def discardContent(contentREs: Set[Regex]) = {
+      rdd.filter(r =>
+        !contentREs.map(re =>
+          (re findFirstIn r.getContentString) match {
+            case Some(v) => true
+            case None => false
+          }).exists(identity))
     }
   }
 


### PR DESCRIPTION
@jrwiebe has developed `keepContent()` and `discardContent()` commands for working with text. I have tested it in the following script:

```scala
import org.warcbase.spark.matchbox._ 
import org.warcbase.spark.rdd.RecordRDD._ 

val r = RecordLoader.loadArchives("/path/to/warc",sc)
.keepValidPages()
.keepContent(Set("guestbooks".r))
.map(r => (r.getCrawlDate, r.getDomain, r.getUrl, RemoveHTML(r.getContentString)))
.saveAsTextFile("out-guestbooks/")
```

This is a much in-demand program, so I'm doing this pull request to merge it all together. 