### PR TITLE
fix the build error when run 'mvn clean package appassembler:assemble…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,4 +54,23 @@
     <module>warcbase-hbase</module>
   </modules>
 
+
+<build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>appassembler-maven-plugin</artifactId>
+        <version>1.10</version>
+        <configuration>
+          <programs>
+            <program>
+              <mainClass>org.warcbase.ingest.IngestFiles</mainClass>
+              <id>IngestFiles</id>
+            </program>
+          </programs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
when i try to run "mvn clean package appassembler:assemble -DskipTests"  command on a ubuntu 16.04 server, i got build error: PluginParameterException. After search online and read the appassembler doc, i managed to fix this build error through editing pom.xml. 


https://cwiki.apache.org/confluence/display/MAVEN/PluginParameterException
http://www.mojohaus.org/appassembler/appassembler-maven-plugin/usage-program.html